### PR TITLE
provide supported options back to protoc/buf

### DIFF
--- a/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/Plugin.java
+++ b/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/Plugin.java
@@ -210,7 +210,26 @@ public final class Plugin {
 
     CodedOutputStream output = CodedOutputStream.newInstance(
       environment.getOutputStream());
+    try {
+      // go ahead and write response preamble
+      CodeGeneratorResponse.newBuilder()
+        // add more here as more features are introduced and then supported
+        .setSupportedFeatures(
+          toFeatureBitmask(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL))
+        .build()
+        .writeTo(output);
+    } catch (IOException e) {
+      throw new PluginException("protoc sent unparseable request to plugin.", e);
+    }
     generator.generate(request, new DescriptorSource(files), new Response(output));
+  }
+
+  private static long toFeatureBitmask(CodeGeneratorResponse.Feature... features) {
+    long result = 0;
+    for (CodeGeneratorResponse.Feature f : features) {
+      result |= f.getNumber();
+    }
+    return result;
   }
 
   private static ExtensionRegistry createExtensionRegistry(Collection<FileDescriptor> files) {

--- a/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/WireGenerator.kt
+++ b/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/WireGenerator.kt
@@ -95,10 +95,9 @@ class WireGenerator(
     val errorCollector = ErrorCollector()
     val linker = Linker(loader, errorCollector, permitPackageCycles = true, loadExhaustively = true)
 
+    val sourcePaths = setOf(*request.fileToGenerateList.toTypedArray())
     val protoFiles = mutableListOf<ProtoFile>()
-    val sourcePaths = mutableSetOf<String>()
     for (fileDescriptorProto in request.protoFileList) {
-      sourcePaths.add(fileDescriptorProto.name)
       val protoFileElement = parseFileDescriptor(fileDescriptorProto, descs)
       val protoFile = ProtoFile.get(protoFileElement)
       protoFiles.add(protoFile)


### PR DESCRIPTION
This will eventually be required in order for the plugin's response to be used for files that include proto3 optional fields.

This also has a tiny fix so we only generate code for the files indicated in the request, instead of for the entire transitive closure of dependencies as well.