### PR TITLE
Clean up oneof parsing

### DIFF
--- a/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/WireGenerator.kt
+++ b/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/WireGenerator.kt
@@ -264,9 +264,8 @@ private fun indexFieldsByOneOf(
   val oneOfMap = mutableMapOf<Int, MutableList<FieldElement>>()
   for ((descriptor, fieldElement) in fields) {
     if (descriptor.hasOneofIndex()) {
-      val list = oneOfMap[descriptor.oneofIndex] ?: mutableListOf()
+      val list = oneOfMap.getOrPut(descriptor.oneofIndex) { mutableListOf() }
       list.add(fieldElement)
-      oneOfMap[descriptor.oneofIndex] = list
     }
   }
   return oneOfMap

--- a/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/WireGenerator.kt
+++ b/wire-library/wire-protoc/src/main/java/com/squareup/wire/protocwire/WireGenerator.kt
@@ -443,15 +443,3 @@ private class SourceCodeHelper(
     return m
   }
 }
-
-/**
- * Helper object for managing message oneof fields and non-oneof fields.
- */
-private class MessageFields(
-  fieldList: List<FieldDescriptorProto>,
-) {
-  val internal = fieldList.mapIndexed { index, fieldDescriptorProto -> index to fieldDescriptorProto }
-  val oneOfFieldList: List<Pair<Int, FieldDescriptorProto>> = internal.filter { elm -> elm.second.hasOneofIndex() }
-  val fieldList: List<Pair<Int, FieldDescriptorProto>> = internal.filter { elm -> !elm.second.hasOneofIndex() }
-}
-


### PR DESCRIPTION
I've been a bit adverse to making changes to the internal wire classes at the moment but it probably would be more ideal if the those wire classes are slightly modified.